### PR TITLE
Unescaped filename in regex pattern causes test failure on Windows

### DIFF
--- a/t/12-no-newline.t
+++ b/t/12-no-newline.t
@@ -10,7 +10,7 @@ use Test::Warnings ':no_end_test', 'warnings';
     my @warnings = warnings { warn "a normal warning"; $line = __LINE__; $file = __FILE__ };
     like(
         $warnings[0],
-        qr/^a normal warning at $file line $line\.?\n$/,
+        qr/^a normal warning at \Q$file\E line $line\.?\n$/,
         'test the appearance of a normal warning',
     );
 }
@@ -22,7 +22,7 @@ use Test::Warnings ':no_end_test', 'warnings';
     my @warnings = warnings { $original_handler->('a warning with no newline'); $line = __LINE__; $file = __FILE__ };
     like(
         $warnings[0],
-        qr/^a warning with no newline at $file line $line.?\n$/,
+        qr/^a warning with no newline at \Q$file\E line $line.?\n$/,
         'warning has origin properly added when it was lacking',
     );
 }


### PR DESCRIPTION
<pre>t\12-no-newline.t .........
#   Failed test 'test the appearance of a normal warning'
t\12-no-newline.t ......... 1/? #   at t\12-no-newline.t line 11.
#                   'a normal warning at t\12-no-newline.t line 10.
# '
#     doesn't match '(?^:^a normal warning at t\12-no-newline.t line 10\.?\n$)'

#   Failed test 'warning has origin properly added when it was lacking'
#   at t\12-no-newline.t line 23.
#                   'a warning with no newline at t\12-no-newline.t line 22.
# '
#     doesn't match '(?^:^a warning with no newline at t\12-no-newline.t line 22.?\n$)'
# Looks like you failed 2 tests of 2.</pre>
