### PR TITLE
Tell the allowed (ignored) pattern to Test::Warnings

### DIFF
--- a/lib/Test/Warnings.pm
+++ b/lib/Test/Warnings.pm
@@ -21,9 +21,20 @@ my $warnings_allowed;
 my $forbidden_warnings_found;
 my $done_testing_called;
 my $no_end_test;
+my $allowed_pattern;
 
 sub import
 {
+    my $i = 0;
+    while ($i < scalar(@_)) {
+        my $a = $_[$i];
+        if ($a eq '-pattern') {
+            (undef, $allowed_pattern) = splice @_, $i, 2;
+            $i++;
+        }
+        $i++;
+    }
+
     # END block will check for this status
     my @symbols = grep { $_ ne ':no_end_test' } @_;
     $no_end_test = (@symbols != @_);
@@ -47,7 +58,7 @@ sub _builder(;$)
 $SIG{__WARN__} = sub {
     my $msg = shift;
 
-    if ($warnings_allowed)
+    if ($warnings_allowed || $msg =~ $allowed_pattern)
     {
         Test::Builder->new->note($msg);
     }

--- a/lib/Test/Warnings.pm
+++ b/lib/Test/Warnings.pm
@@ -28,7 +28,7 @@ sub import
     my $i = 0;
     while ($i < scalar(@_)) {
         my $a = $_[$i];
-        if ($a eq '-pattern') {
+        if ($a eq '-allowed_pattern') {
             (undef, $allowed_pattern) = splice @_, $i, 2;
             $i++;
         }
@@ -58,7 +58,7 @@ sub _builder(;$)
 $SIG{__WARN__} = sub {
     my $msg = shift;
 
-    if ($warnings_allowed || $msg =~ $allowed_pattern)
+    if ($warnings_allowed || ($allowed_pattern && $msg =~ $allowed_pattern))
     {
         Test::Builder->new->note($msg);
     }

--- a/t/13-pattern.t
+++ b/t/13-pattern.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
-use Test::Warnings ':all', -pattern => qr/\bOK\b/;
+use Test::Warnings ':all', -allowed_pattern => qr/\bOK\b/;
 
 ok 1;
 warn 'Maybe OK';

--- a/t/13-pattern.t
+++ b/t/13-pattern.t
@@ -1,0 +1,9 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Warnings ':all', -pattern => qr/\bOK\b/;
+
+ok 1;
+warn 'Maybe OK';
+
+done_testing;


### PR DESCRIPTION
Usage:

``` perl
use strict;
use warnings;
use Test::More;
use Test::Warnings ':all', -pattern => qr/\bOK\b/;

ok 1;
warn 'Maybe OK';

done_testing;
```

We can assumes that no warnings found except some allowed warnings.
