### PR TITLE
fix warnings->import being called after importing "warnings" sub

### DIFF
--- a/lib/Test/Warnings.pm
+++ b/lib/Test/Warnings.pm
@@ -77,8 +77,14 @@ $SIG{__WARN__} = sub {
     }
 };
 
-sub warnings(&)
+sub warnings(;&)
 {
+    # if someone manually does warnings->import in the same namespace this is
+    # imported into, this sub will be called.  in that case, just return the
+    # string "warnings" so it calls the correct method.
+    if (!@_) {
+        return 'warnings';
+    }
     my $code = shift;
     my @warnings;
     local $SIG{__WARN__} = sub {

--- a/t/22-warnings-bareword.t
+++ b/t/22-warnings-bareword.t
@@ -1,0 +1,31 @@
+use strict;
+use warnings;
+
+use Test::More 0.88;
+use Test::Warnings ':no_end_test', 'warnings';
+
+my $e;
+my $no_warn_sub;
+my $warn_sub;
+{
+    no warnings;
+    if (!eval q{
+        $no_warn_sub = sub { return 1 + undef };
+        BEGIN { warnings->import }
+        $warn_sub = sub { return 1 + undef };
+        1;
+    }) {
+        $e = $@;
+    }
+}
+
+is $e, undef,
+    'warnings->import succeeds after importing "warnings" sub';
+
+ok !warnings { $no_warn_sub->() },
+    'no warnings worked as expected';
+
+like +(warnings { $warn_sub->() })[0], qr{uninitialized value},
+    'correct warnings were enabled after warnings->import';
+
+done_testing;


### PR DESCRIPTION
If the user imports the "warnings" sub, it will take priority over the
bareword 'warnings'.  This means that a manually written
"warnings->import" call will try to call the warnings sub from this
module.  One example of this is older versions of File::pushd, which
conditionally called warnings->import before setting their package, so
it will instead happen in whatever package the module was loaded from.

We can mark the sub argument as optional, which shouldn't ever normally
happen except for when trying to call a method on warnings.  Then we can
check the number of arguments to detect this, and return the string
'warnings', allowing method lookup to proceed like normal.