### PR TITLE
WIP Add :report_warnings functionality

### DIFF
--- a/t/23-report-warnings.t
+++ b/t/23-report-warnings.t
@@ -1,0 +1,17 @@
+use strict;
+use warnings;
+
+use Test::More 0.88;
+use Test::Warnings qw/ :report_warnings /;
+
+# TODO test without Test::Output
+use Test::Output qw/ stderr_like /;
+
+stderr_like sub {
+    say STDERR "foo";
+    warn "warning 1";
+    warn "warning 2";
+}, qr{foo}, 'test';
+
+done_testing;
+


### PR DESCRIPTION
If a test uses Test::Output::stderr_like for example, which captures
STDERR, any additional warning in that block is not seen in the output,
but is reported correctly by Test::Warnings.
So it requires manual changes to find out what the warning was.

Wrapping an explicit `warnings {}` around those calls and printing
the warnings helps, but is not really usable when there are many
tests like this.

This change reports the actual contents of those warnings at the end (if
requested).
```
use Test::Warnings qw/ :report_warnings /;
```

I still need to find out how to make the new test not fail, and
also replace Test::Output with a simple STDERR redirection.