### PR TITLE
Add environment variable to make warnings non fatal

### DIFF
--- a/lib/Test/Warnings.pm
+++ b/lib/Test/Warnings.pm
@@ -143,7 +143,13 @@ sub allowing_warnings() { $warnings_allowed }
 
 # call at any time to assert no (unexpected) warnings so far
 sub had_no_warnings(;$) {
-    _builder->ok(!$forbidden_warnings_found, shift || 'no (unexpected) warnings');
+    if ($ENV{PERL_TEST_WARNINGS_ONLY_REPORT_WARNINGS}) {
+        $forbidden_warnings_found
+            and _builder->diag("Found $forbidden_warnings_found warnings but allowing them because PERL_TEST_WARNINGS_ONLY_REPORT_WARNINGS is set");
+    }
+    else {
+        _builder->ok(!$forbidden_warnings_found, shift || 'no (unexpected) warnings');
+    }
     if ($report_warnings and $forbidden_warnings_found) {
         _builder->diag("Got the following unexpected warnings:");
         for my $i (1 .. @collected_warnings) {

--- a/t/24-only-report-warnings.t
+++ b/t/24-only-report-warnings.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+
+my $has_test_tester;
+BEGIN { $has_test_tester = eval { require Test::Tester; Test::Tester->VERSION(0.108); 1 } }
+
+use Test::More 0.88;
+plan skip_all => 'These tests require Test::Tester 0.108' if not $has_test_tester;
+plan tests => 1;
+
+use if "$]" >= '5.008', lib => 't/lib';
+use if "$]" >= '5.008', 'SilenceStderr';
+
+$ENV{PERL_TEST_WARNINGS_ONLY_REPORT_WARNINGS} = 1;
+use Test::Warnings qw(had_no_warnings :report_warnings :no_end_test);
+Test::Warnings::_builder(my $capture = Test::Tester::capture());
+
+warn 'this is a warning 1 2 3'; my $line = __LINE__;
+
+my (undef, @results) = Test::Tester::run_tests(sub { had_no_warnings; });
+
+Test::Tester::cmp_results(
+    [ $capture->details ],
+    [ ],
+    'with "PERL_TEST_WARNINGS_ONLY_REPORT_WARNINGS" set, test does not fail',
+);


### PR DESCRIPTION
This can be useful to temporarily make tests not fatal if there is a known warning that cannot be easily avoided.

Set PERL_TEST_WARNINGS_ONLY_REPORT_WARNINGS to only get a report at the end (if :report_warnings is used).

Fixes #12 

I'm not sure how to check the expected diag output in the test.